### PR TITLE
add junt to pom.xml and fix negative Integer bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,5 +13,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
         </dependency>
+        <dependency>
+        	<groupId>junit</groupId>
+        	<artifactId>junit</artifactId>
+        	<version>4.10</version>
+        <scope>test</scope>
+    </dependency>
     </dependencies>
 </project>

--- a/src/main/java/be/christophedetroyer/bencoding/Reader.java
+++ b/src/main/java/be/christophedetroyer/bencoding/Reader.java
@@ -210,7 +210,8 @@ public class Reader
         // They are represented as ASCII numbers.
         String intString = "";
         byte current = readCurrentByte();
-        while (current >= 48 && current <= 57)
+        //45 negative mark
+        while (current >= 48 && current <= 57 || current == 45)
         {
             intString = intString + Character.toString((char)current);
             currentByteIndex++;


### PR DESCRIPTION
negative integer bug fixed .
some torrent cant pasre well.

here is a torrent file which cant not parse well.

change the ext pdf to torrent to test

[【720p高清】007：大破天幕杀机Skyfall.2012.1.05GB.pdf](https://github.com/m1dnight/torrent-parser/files/737312/720p.007.Skyfall.2012.1.05GB.pdf)

in the torrent,there a lot of "i-1e" .


